### PR TITLE
[PLAT-1999] Reload upon ticket merge

### DIFF
--- a/app.js
+++ b/app.js
@@ -263,7 +263,7 @@
       this.mergeHandler(tickets)
         .done(function() {
            this.mergeOneSuccess(MERGE_INTO_SUCCESS_NOTIFICATIONS, ticketID);
-           location.reload();
+           this.reloadAfterMerge();
          }).fail(function() {
            $ticketItem.replaceWith(_.sample(FAILURE_NOTIFICATIONS));
          });
@@ -282,7 +282,7 @@
       this.mergeHandler(tickets)
        .done(function() {
          this.mergeOneSuccess(MERGE_OUT_SUCCESS_NOTIFICATIONS, ticketID);
-         location.reload();
+         this.reloadAfterMerge();
          // also hide other merge buttons, since the current ticket is now closed
          this.$('.merge-in').hide();
          this.$('.merge-out').hide();
@@ -322,12 +322,23 @@
       this.mergeHandler(tickets)
         .done(function() {
           $mergeModal.find('.modal-body').html(_.sample(MERGE_SELECTED_SUCCESS_NOTIFICATIONS));
-          location.reload();
+          this.reloadAfterMerge();
           // hide app when user dismisses modal
           $mergeModal.find('.merge-multi-close').addClass('hide-app');
         }).fail(function() {
           $mergeModal.find('.modal-body').html('fail');
         });
+    },
+
+    reloadAfterMerge: function() {
+      // Unfortunately, this is now necessary after some changes on Zendesk's side
+      // that will create problems on ticket update if there has been an update made by
+      // another actor (like this app). If something ever changes in that aspect, we should take this off.
+
+      // The timeout is necessary because otherwise it's possible to reload the ticket after the app knows
+      // of the merge success but before the ticket knows of the changes made to it.
+      // TODO: Remove the timeout race condition and replace it by a check on the last comment of the current ticket.
+      setTimeout(function(){ location.reload(); }, 1500);
     },
 
     mergeHandler: function(tickets) {

--- a/app.js
+++ b/app.js
@@ -57,7 +57,7 @@
     requests: {
       getTicketsByUser: function(user) {
         return {
-          url:  '/api/v2/users/' + user.id() + '/tickets/requested.json',
+          url:  '/api/v2/users/' + user.id() + '/tickets/requested.json?sort_order=desc',
           type: 'GET'
         };
       },
@@ -122,7 +122,6 @@
             this.$('.modal-container').html(this.renderTemplate('multi_merge_modal'));
             this.$('.modal-container').after(this.renderTemplate('save_confirm_modal'));
           }
-
         }).fail(function(){
           this.switchTo('error');
           this.show();
@@ -264,6 +263,7 @@
       this.mergeHandler(tickets)
         .done(function() {
            this.mergeOneSuccess(MERGE_INTO_SUCCESS_NOTIFICATIONS, ticketID);
+           location.reload();
          }).fail(function() {
            $ticketItem.replaceWith(_.sample(FAILURE_NOTIFICATIONS));
          });
@@ -282,6 +282,7 @@
       this.mergeHandler(tickets)
        .done(function() {
          this.mergeOneSuccess(MERGE_OUT_SUCCESS_NOTIFICATIONS, ticketID);
+         location.reload();
          // also hide other merge buttons, since the current ticket is now closed
          this.$('.merge-in').hide();
          this.$('.merge-out').hide();
@@ -321,6 +322,7 @@
       this.mergeHandler(tickets)
         .done(function() {
           $mergeModal.find('.modal-body').html(_.sample(MERGE_SELECTED_SUCCESS_NOTIFICATIONS));
+          location.reload();
           // hide app when user dismisses modal
           $mergeModal.find('.merge-multi-close').addClass('hide-app');
         }).fail(function() {


### PR DESCRIPTION
[PLAT-1999](https://lumoslabs.atlassian.net/browse/PLAT-1999)

This is not my ideal solution, but it may be very possibly the only one to avoid the "A change was made to this ticket as your update was being saved." 

We are also grabbing "only" 100 tickets from the current user  because we are not following up with zendesk's pagination, so  this also asks for tickets in descending order so that at least we get the most recent tickets.

In the future we could work on actually using pagination (opened a ticket about it) although it's low priotrity because customers with more than 100 tickets are exceptional and most likely you an agent will not have to merge a ticket from so long ago.